### PR TITLE
fix(setup):fix installation dependencies ..

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,5 @@ RUN pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/we
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt --no-cache
+# 安装nltk数据包
+RUN python -m nltk.downloader punkt_tab  punkt wordnet

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,3 @@ RUN pip config set global.index-url https://mirrors.tuna.tsinghua.edu.cn/pypi/we
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt --no-cache
-# 安装nltk数据包
-RUN python -m nltk.downloader punkt_tab  punkt wordnet

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python pipeline.py
 1. Create a conda environment (optional)
 
 ```shell
-conda create -n trustrag python=3.9
+conda create -n trustrag python=3.12.0
 conda activate trustrag
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -107,7 +107,7 @@ python pipeline.py
 1. 创建conda环境（可选）
 
 ```sehll
-conda create -n trustrag python=3.9
+conda create -n trustrag python=3.12.0
 conda activate trustrag
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,14 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "trustrag"
-version = "0.1.0"
+version = "0.15.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
-dependencies = []
+requires-python = ">=3.11.0"
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
-try:
-    from trustrag.version import __version__
-except ImportError:
-    __version__ = "unknown version"
+
+__version__ = "0.15.0"
 
 # 读取 requirements.txt 文件中的内容
 with open('requirements.txt') as f:
@@ -21,5 +19,5 @@ setup(
     long_description=open('README.md','r',encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     url="https://github.com/gomate-community/TrustRAG",
-    python_requires='>=3.9',
+    python_requires='>=3.11.0',
 )

--- a/trustrag/version.py
+++ b/trustrag/version.py
@@ -1,3 +1,0 @@
-"""GoMate version file."""
-
-__version__ = '0.0.15'


### PR DESCRIPTION
主要修复

1. 修复使用源码构建时，自动根据requirement安装依赖包的问题。
```
pip install -e . 
```
2. 修改readme中关于构建虚拟环境时的描述，python的版本号，最好是python==3.12.0. 否则会有依赖冲突。
3. 要使用Qwen系列，需要 transformers>=4.53